### PR TITLE
add meteor support for xmlhttprequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "xmlhttprequest": "^1.8.0"
   },
   "browser": {
-    "xmlhttprequest": false,
-    "./src/lib/XMLHttpRequest.js": "./src/lib/XMLHttpRequest-browser.js",
-    "./lib/lib/XMLHttpRequest.js": "./lib/lib/XMLHttpRequest-browser.js"
+    "xmlhttprequest": false
   },
   "jest": {
     "coverageDirectory": "./coverage/",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ var BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 var base58 = require('base-x-bytearray')(BASE58)
 var hex = require('base-x-bytearray')('0123456789abcdef')
 
-const XMLHttpRequest = require('./lib/XMLHttpRequest')
+const XMLHttpRequest = window.XMLHttpRequest || require('xmlhttprequest').XMLHttpRequest
 
 const getAttributesData = '0x446d5aa4000000000000000000000000'
 function http (opts, callback) {

--- a/src/lib/XMLHttpRequest-browser.js
+++ b/src/lib/XMLHttpRequest-browser.js
@@ -1,3 +1,0 @@
-const XMLHttpRequest = window.XMLHttpRequest; // eslint-disable-line
-
-module.exports = XMLHttpRequest;

--- a/src/lib/XMLHttpRequest.js
+++ b/src/lib/XMLHttpRequest.js
@@ -1,3 +1,0 @@
-const XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
-
-module.exports = XMLHttpRequest;


### PR DESCRIPTION
Meteor builds include node-xmltthprequest rather than using window.xmlhttprequest. node-xmltthprequest has a bug in it, and doesn't seem to be pulling in PRs. Meteor builds use node-xmltthprequest since it ignores the browser field in the package.json, unless it is just a string - https://github.com/meteor/meteor/issues/6890#issuecomment-214032062 . These changes allows meteor to use window.xmlhttprequest. (also reduces code, and does not affect local webpack builds)